### PR TITLE
Feature, adding onetimecopy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ Ubuntu-based Bucardo image for Docker Containers.
       {
         "sources": [3],
         "targets": [1,2],
-        "tables": "client"
+        "tables": "client",
+        "onetimecopy": 1
       },{
         "sources": [1,2],
         "targets": [3],
-        "tables": "product, order"
+        "tables": "product, order",
+        "onetimecopy": 0
       }
     ]
   }
@@ -68,6 +70,11 @@ Ubuntu-based Bucardo image for Docker Containers.
 
   * The other attribute required is the syncs' *table lists*. A *table list* is a String containing the tables sync'd by that sync, separated by a comma and a space, as in the example above.
 
+  * [Onetimecopy](https://bucardo.org/wiki/Onetimecopy) is used describe if a full table copy is required:
+    - 0 No full copy is done
+    - 1 A full table copy is always performed
+    - 2 A full copy is done in case the destination table is empty
+    
 4. Start the container with a command such as:
 
   ```bash

--- a/example/bucardo.json
+++ b/example/bucardo.json
@@ -23,11 +23,13 @@
     {
       "sources": [0],
       "targets": [1,2],
-      "tables": "client"
+      "tables": "client",
+      "onetimecopy": 1
     },{
       "sources": [1,2],
       "targets": [0],
-      "tables": "product, order"
+      "tables": "product, order",
+      "onetimecopy": 0
     }
   ]
 }

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -90,6 +90,15 @@ sync_attr() {
   echo $value
 }
 
+#First validate onetimecopy is an integer and then validate if it's 0,1 or 2
+one_time_copy_attr() {
+  local sync_index=$1
+  local value=$(sync_attr $sync_index onetimecopy integer)
+  local invalid_chars=$(echo $string_attr | sed -e "s/[0,1,2]//")
+  check_invalid_chars $value $invalid_chars
+  echo $value 
+}
+
 load_db_pass() {
   local database=$1
   local pass=$(db_attr $database pass)
@@ -147,10 +156,12 @@ add_syncs_to_bucardo() {
   while [[ $sync_index -lt $num_syncs ]]; do
     echo "[CONTAINER] Adding sync$sync_index to Bucardo..."
     db_sync_string $sync_index
+    local one_time_copy="$(one_time_copy_attr $sync_index)"
     run_bucardo_command "del sync sync$sync_index"
     run_bucardo_command "add sync sync$sync_index \
                          dbs=$DB_STRING \
-                         tables=$(sync_attr $sync_index tables)"
+                         tables=$(sync_attr $sync_index tables) \
+                         onetimecopy=$one_time_copy"
     sync_index=$(expr $sync_index + 1)
   done
 }


### PR DESCRIPTION
The onetimecopy mode of a sync instructs it to temporarily switch from a pushdelta mode to a fullcopy mode.